### PR TITLE
chore: migrate FastURLFilter to AWS SDK v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@ under the License.
 			<artifactId>s3</artifactId>
 		</dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+        </dependency>
+
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ under the License.
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<stormcrawler.version>3.6.0</stormcrawler.version>
 		<storm.version>2.8.8</storm.version>
-		<aws.version>1.12.797</aws.version>
+		<aws.version>2.46.7</aws.version>
 		<jackson.version>2.21.3</jackson.version>
 		<crawler-commons.version>1.6</crawler-commons.version>
 		<mockito.version>5.23.0</mockito.version>
@@ -49,6 +49,18 @@ under the License.
 		<git-code-format-maven-plugin.version>5.4</git-code-format-maven-plugin.version>
 		<skip.format.code>true</skip.format.code>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>${aws.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<dependency>
@@ -86,9 +98,8 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-s3</artifactId>
-			<version>${aws.version}</version>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/commoncrawl/stormcrawler/filter/FastURLFilter.java
+++ b/src/main/java/org/commoncrawl/stormcrawler/filter/FastURLFilter.java
@@ -41,6 +41,7 @@ import org.apache.stormcrawler.filtering.URLFilter;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -173,7 +174,7 @@ public class FastURLFilter extends URLFilter implements JSONResource {
         try {
             if (getResourceFile().startsWith("s3://")) {
                 // try loading from S3
-                s3client = S3Client.builder().build();
+                s3client = S3Client.builder().httpClient(UrlConnectionHttpClient.create()).build();
                 java.net.URI uri = new java.net.URI(getResourceFile());
 
                 String bucketName = uri.getHost();

--- a/src/main/java/org/commoncrawl/stormcrawler/filter/FastURLFilter.java
+++ b/src/main/java/org/commoncrawl/stormcrawler/filter/FastURLFilter.java
@@ -184,11 +184,7 @@ public class FastURLFilter extends URLFilter implements JSONResource {
                 // optimisation - avoid a full reload if the resource has not changed
                 HeadObjectResponse headResponse =
                         s3client.headObject(
-                                HeadObjectRequest.builder()
-                                                 .bucket(bucketName)
-                                                 .key(path)
-                                                 .build()
-                        );
+                                HeadObjectRequest.builder().bucket(bucketName).key(path).build());
                 final String ETAG = headResponse.eTag();
                 if (ETAG != null && ETAG.equals(resourceETAG)) {
                     LOG.info("Unchanged ETAG for {} - skipping reload", getResourceFile());
@@ -199,11 +195,7 @@ public class FastURLFilter extends URLFilter implements JSONResource {
 
                 inputStream =
                         s3client.getObject(
-                                GetObjectRequest.builder()
-                                                .bucket(bucketName)
-                                                .key(path)
-                                                .build()
-                        );
+                                GetObjectRequest.builder().bucket(bucketName).key(path).build());
             } else {
                 inputStream = getClass().getClassLoader().getResourceAsStream(getResourceFile());
                 if (inputStream == null) {

--- a/src/main/java/org/commoncrawl/stormcrawler/filter/FastURLFilter.java
+++ b/src/main/java/org/commoncrawl/stormcrawler/filter/FastURLFilter.java
@@ -16,11 +16,6 @@
  */
 package org.commoncrawl.stormcrawler.filter;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.S3Object;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -46,6 +41,10 @@ import org.apache.stormcrawler.filtering.URLFilter;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 /**
  * Version of the FastURLFilter that can load from a text representation instead of the JSON that
@@ -170,11 +169,11 @@ public class FastURLFilter extends URLFilter implements JSONResource {
     @Override
     public void loadJSONResources() throws Exception {
         InputStream inputStream = null;
-        AmazonS3 s3client = null;
+        S3Client s3client = null;
         try {
             if (getResourceFile().startsWith("s3://")) {
                 // try loading from S3
-                s3client = AmazonS3ClientBuilder.standard().build();
+                s3client = S3Client.builder().build();
                 java.net.URI uri = new java.net.URI(getResourceFile());
 
                 String bucketName = uri.getHost();
@@ -182,8 +181,14 @@ public class FastURLFilter extends URLFilter implements JSONResource {
                 String path = uri.getPath().substring(1);
 
                 // optimisation - avoid a full reload if the resource has not changed
-                ObjectMetadata metadata = s3client.getObjectMetadata(bucketName, path);
-                final String ETAG = metadata.getETag();
+                HeadObjectResponse headResponse =
+                        s3client.headObject(
+                                HeadObjectRequest.builder()
+                                                 .bucket(bucketName)
+                                                 .key(path)
+                                                 .build()
+                        );
+                final String ETAG = headResponse.eTag();
                 if (ETAG != null && ETAG.equals(resourceETAG)) {
                     LOG.info("Unchanged ETAG for {} - skipping reload", getResourceFile());
                     return;
@@ -191,8 +196,13 @@ public class FastURLFilter extends URLFilter implements JSONResource {
                     resourceETAG = ETAG;
                 }
 
-                final S3Object object = s3client.getObject(new GetObjectRequest(bucketName, path));
-                inputStream = object.getObjectContent();
+                inputStream =
+                        s3client.getObject(
+                                GetObjectRequest.builder()
+                                                .bucket(bucketName)
+                                                .key(path)
+                                                .build()
+                        );
             } else {
                 inputStream = getClass().getClassLoader().getResourceAsStream(getResourceFile());
                 if (inputStream == null) {
@@ -210,7 +220,7 @@ public class FastURLFilter extends URLFilter implements JSONResource {
                 inputStream.close();
             }
             if (s3client != null) {
-                s3client.shutdown();
+                s3client.close();
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/commoncrawl/news-crawl/issues/77

Step-by-step migration instructions from AWS SDK v1 to v2: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-steps.html
cf. https://github.com/apache/stormcrawler/pull/1939/changes

This PR updates:
- [x] pom.xml in 4 places:
    - [x] ${aws.version}
    - [x] dependency on aws s3 artifact
    - [x] additional dependency on aws `url-connection-client` artifact, which seems necessary in sdk v2 for building the s3 client
    - [x] dependencyManagement/BOM (bill of materials) that pins all AWS SDK v2 versions, recommended by AWS SDK v2
- [x] stormcrawler/filter/FastURLFilter.java
     - [x] `software.amazon.awssdk.services.s3.model.HeadObjectResponse` is the SDK v2 equivalent we need for `ObjectMetadata`, more specifically it corresponds to what returned from `getObjectMetadata` in v1, cf. https://docs.aws.amazon.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#headObject
     - [x] Get inputStream via `GetObjectRequest.builder().build()`
     - [x] close() instead of shutdown()
- ~~[] migrate test: `FastURLFilterTest.java`~~
     - Existing test already runs, nothing to check from S3.
     - I tried adding a new test using [Adobe's S3 mocking library](https://github.com/adobe/S3Mock) but it is very heavy-weight and too many version clashes. It is recommended to use with Docker, which is more than what we bargained for here.
- [x] Run news-crawler with production config for manual test. 
    - [x] Test with dedicated simple fast-urlfilter file and `bin/sc-main-run.sh`, cf. https://github.com/commoncrawl/news-crawl/pull/82
        - [x] Testfile uploaded at `s3://commoncrawl-dev/hande-aws-sdk-v2-test/fast-urlfilter-test.txt.gz`, with content:
           ```
           Host localhost
             DenyPath .*
           Host 127.0.0.1
             DenyPath .*
           Domain blocked.com
             DenyPath .*
           ```
        - [x] Point to test file with `urlfilters-test.json`:
           ```
           {
            "org.apache.stormcrawler.filtering.URLFilters": [
              {
                "class": "org.commoncrawl.stormcrawler.filter.FastURLFilter",
                "params": {
                  "file": "s3://commoncrawl-dev/hande-aws-sdk-v2-test/fast-urlfilter-test.txt.gz"
                }
              }
            ]
          }
          ```
          - [x] Test with blocked/allowed cases:
              - [x] `bash bin/sc-main-run.sh urlfilter -f urlfilters-test.json https://blocked.com`: returns `null` as expected.
              - [x] `bash bin/sc-main-run.sh urlfilter -f urlfilters-test.json https://example.org` returns `https://example.org` as expected.

    - [x] Run production configuration to read the deployed production fast-urlfilter file from s3.
        - Ran by:
            - copying `conf/crawler.flux` from `news-crawl-production::private-production-3.x`
            - copying fast-urliflter related bits from `conf/crawler-conf.yaml` also from above, which is:
               ```
               # take precedence over content of filter.json
                fast.urlfilter.refresh: 60
                fast.urlfilter.file: "s3://commoncrawl-news-crawler/fast-urlfilter.txt.gz"
                ```
                - running `$STORM_HOME/bin/storm local target/crawler-3.6.0.jar --local-ttl 60 -- org.commoncrawl.stormcrawler.news.CrawlTopology -conf $PWD/conf/opensearch-conf.yaml -conf $PWD/conf/crawler-conf.yaml $PWD/seeds/ feeds.txt`  (OpenSearch and Storm initialized properly)

        - Successfully results in:
          ```
          14:14:14.907 [Thread-49-prefilter-executor[12, 12]] INFO  o.c.s.f.FastURLFilter - Loaded 335 hostrules and 3330 domain rules in 144 msec from s3://commoncrawl-news-crawler/fast-urlfilter.txt.gz
          14:14:14.909 [Thread-49-prefilter-executor[12, 12]] INFO  o.c.s.f.FastURLFilter - Filter set to reload from s3://commoncrawl-news-crawler/fast-urlfilter.txt.gz every 60 sec
          14:14:14.910 [Thread-49-prefilter-executor[12, 12]] INFO  o.a.s.u.ConfigurableHelper - Setup <unnamed>[org.commoncrawl.stormcrawler.filter.FastURLFilter]
          14:14:14.910 [Thread-49-prefilter-executor[12, 12]] INFO  o.a.s.e.b.BoltExecutor - Prepared bolt prefilter:[12]
           ```
