### PR TITLE
Enable IPv6

### DIFF
--- a/conf/crawler-conf.yaml
+++ b/conf/crawler-conf.yaml
@@ -13,7 +13,7 @@ config:
   topology.debug: false
 
   # override the JVM parameters for the workers
-  topology.worker.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true"
+  topology.worker.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=false"
 
   topology.name: "NewsCrawl"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,8 @@ services:
   zookeeper:
     image: zookeeper:${ZOOKEEPER_VERSION:-3.9.4}
     container_name: zookeeper-news-crawl
+    networks:
+      - storm-network-news-crawl
     restart: always
 
   # - the daemon Nimbus runs on the master node
@@ -31,6 +33,8 @@ services:
       - zookeeper
     links:
       - zookeeper
+    networks:
+      - storm-network-news-crawl
     ports:
       - 6627:6627
     restart: always
@@ -53,6 +57,8 @@ services:
       - opensearch
     # - the WARC output folder
     # - and the seed folder
+    networks:
+      - storm-network-news-crawl
     volumes:
       - ${WARCOUTPUT:-./warcdata}:/data/warc
       - ${SEEDDIR:-./seeds}:/data/seeds
@@ -67,6 +73,8 @@ services:
       - storm-nimbus
     links:
       - storm-nimbus:nimbus
+    networks:
+      - storm-network-news-crawl
     ports:
       - "127.0.0.1:8080:8080"
     restart: always
@@ -91,12 +99,16 @@ services:
       nofile:
         soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
         hard: 65536
+    networks:
+      - storm-network-news-crawl
     ports:
       - "127.0.0.1:9200:9200" # REST API
 
   opensearch-dashboard:
     image: opensearchproject/opensearch-dashboards:${OPENSEARCH_VERSION:-2.19.5}
     container_name: opensearch-dashboard-news-crawl
+    networks:
+      - storm-network-news-crawl
     ports:
       - "127.0.0.1:5601:5601"
     expose:
@@ -115,8 +127,13 @@ services:
       - storm-nimbus
     links:
       - storm-nimbus:nimbus
+    networks:
+      - storm-network-news-crawl
     volumes:
       - ${WARCOUTPUT:-./warcdata}:/data/warc
       - ${SEEDDIR:-./seeds}:/data/seeds
     restart: "no"
 
+networks:
+  storm-network-news-crawl:
+    enable_ipv6: true


### PR DESCRIPTION
Configure components to allow IPv6
- Docker Compose network enable IPv6
- Storm topology crawl worker: set `java.net.preferIPv4Stack=false`

Of course, this works only if the crawler machine also has IPv6.

Tested. The WARC records now show IPv6 addresses:
```
WARC/1.0
WARC-Type: request
WARC-IP-Address: 2620:cb:2000:0:0:0:0:1
WARC-Record-ID: <urn:uuid:cdf789da-09e4-468f-908a-021e08c8550f>
Content-Length: 251
WARC-Date: 2026-07-02T14:00:03Z
WARC-Target-URI: https://commoncrawl.org/ccbot
```

The IPv6 address has the wrong format. To be addressed separately.