### PR TITLE
Update documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ mvn clean package
 Verify the configuration in the file [docker-compose.yaml](docker-compose.yaml) and [conf/](conf/) is correct:
 - Don't forget to adapt the paths to mounted volumes used to persist data (OpenSearch indexes and WARC files).
 - Make sure to add the user agent configuration in conf/crawler-conf.yaml.
-- If the FastURLFilter rules file is loaded from S3 (`fast.urlfilter.file: "s3://..."` in `conf/`), the worker needs AWS credentials and a region. The `storm-supervisor` service selects a named profile via `AWS_PROFILE`/`AWS_REGION` (defaults in [docker-compose.yaml](docker-compose.yaml), overridable through a `.env` file) and mounts the host's `~/.aws` read-only at `/home/storm/.aws`. It is mounted there — the `storm` user's home — rather than `/root`, because the worker JVM runs as the `storm` user, so that is where the AWS SDK's default `~/.aws` lookup resolves. Make sure the profile exists in your `~/.aws/credentials` (and `~/.aws/config` for region / SSO / role).
+- If the FastURLFilter rules file is loaded from S3 (`fast.urlfilter.file: "s3://..."` in `conf/`) the worker needs AWS credentials. 
 
 Then download and build the Docker images:
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,28 @@
 Crawler for news based on [StormCrawler](https://stormcrawler.apache.org/). Produces WARC files to be stored as part of the [Common Crawl](https://commoncrawl.org/). The data is hosted as [AWS Open Data Set](https://registry.opendata.aws/) – if you want to use the data and not the crawler software please read [the announcement of the news dataset](https://commoncrawl.org/2016/10/news-dataset-available/).
 
 
+## How it works
+
+The project is a custom [Apache StormCrawler](https://stormcrawler.apache.org/) topology. Stock StormCrawler provides the heavy machinery — the HTTP fetcher, robots.txt handling, URL partitioner, WARC writer and OpenSearch status index. This repository adds ~10 **news-specific** bolts and filters on top (parsing Google News sitemaps, detecting RSS/Atom feeds, news-aware URL filtering).
+
+Two indexes / stores are involved:
+
+- **OpenSearch** holds the *URL status index*: every known URL and its state (`DISCOVERED`, `FETCHED`, `REDIRECTION`, `ERROR`). This is the crawler's memory of what to fetch next.
+- **WARC files** on local disk (`warc.dir`) hold the actual fetched content — this is the output shipped to Common Crawl.
+
+The production crawl ([`CrawlTopology`](src/main/java/org/commoncrawl/stormcrawler/news/CrawlTopology.java)) is a Storm pipeline:
+
+```
+seeds/feeds.txt
+  → FileSpout → PreFilterBolt → URLPartitionerBolt → FetcherBolt
+  → {NewsSiteMapParserBolt, FeedParserBolt}          (extract article links)
+  → WARCHdfsBolt (write content to WARC on disk)
+  + StatusUpdaterBolt (write URL states to OpenSearch)
+```
+
+Feeds and sitemaps are re-fetched on a schedule to discover new articles; the article URLs they yield are queued in the status index and fetched in turn.
+
+
 ## Prerequisites
 * JVM 17 or higher
 * Install OpenSearch 2.19.5
@@ -44,18 +66,33 @@ Alternatively, the topology can be run from the [crawler.flux](./conf/crawler.fl
 In production, you should use `storm jar ...` to run the topology in distributed mode and continuously (no time limit) including the Storm UI and logging.
 
 
+## Bootstrap: discovering feeds and sitemaps
+
+The production crawl assumes its seeds are *already known* to be feeds or news sitemaps. When you only have a list of candidate URLs (e.g. news site home pages) and don't yet know which of them expose a feed or a Google News sitemap, run the **bootstrap topology** first.
+
+[`BootstrapTopology`](src/main/java/org/commoncrawl/stormcrawler/news/bootstrap/BootstrapTopology.java) reuses the same fetch skeleton but replaces the *parser* bolts with *detector* bolts — [`NewsSiteMapDetectorBolt`](src/main/java/org/commoncrawl/stormcrawler/news/bootstrap/NewsSiteMapDetectorBolt.java) and [`FeedDetectorBolt`](src/main/java/org/commoncrawl/stormcrawler/news/FeedDetectorBolt.java) — which classify a fetched URL by its content/`Content-Type` instead of extracting article links from it. The detected feeds and sitemaps can then be used as seeds for the production crawl above.
+
+It uses its own configuration ([conf/bootstrap-conf.yaml](conf/bootstrap-conf.yaml)), which sets a distinct WARC output directory and a more conservative `fetcher.server.delay`. Run it like the production topology, but with the bootstrap main class and config:
+
+``` sh
+storm local target/crawler-3.6.0.jar --local-ttl 60 -- org.commoncrawl.stormcrawler.news.bootstrap.BootstrapTopology -conf $PWD/conf/opensearch-conf.yaml -conf $PWD/conf/bootstrap-conf.yaml $PWD/seeds/ feeds.txt
+```
+
+
 ## Monitor the crawl
 
 When the topology is running you can check that URLs have been injected and news are getting fetched on <http://localhost:9200/status/_search?pretty>. Or use StormCrawler's OpenSearch dashboards to monitor the crawling process on <http://localhost:5601/>.
 
-There is also a shell script [bin/status](./bin/status) to get aggregated counts from the status index, and to add, delete or force a re-fetch of URLs. E.g., 
+There is also a shell script [bin/status](./bin/status) to get aggregated counts from the status index, and to add, delete or force a re-fetch of URLs. E.g.,
 
 ```
-$> bin/es_status aggregate_status
+$> bin/status aggregate_status
 3824    DISCOVERED
 34      FETCHED
 5       REDIRECTION
 ```
+
+Run `bin/status` without arguments to see the full list of sub-commands (each sub-command is a function inside the script). Pass `-C` to colorize the JSON output.
 
 
 ## Run Crawl with Docker Compose
@@ -69,6 +106,7 @@ mvn clean package
 Verify the configuration in the file [docker-compose.yaml](docker-compose.yaml) and [conf/](conf/) is correct:
 - Don't forget to adapt the paths to mounted volumes used to persist data (OpenSearch indexes and WARC files).
 - Make sure to add the user agent configuration in conf/crawler-conf.yaml.
+- If the FastURLFilter rules file is loaded from S3 (`fast.urlfilter.file: "s3://..."` in `conf/`), the worker needs AWS credentials and a region. The `storm-supervisor` service selects a named profile via `AWS_PROFILE`/`AWS_REGION` (defaults in [docker-compose.yaml](docker-compose.yaml), overridable through a `.env` file) and mounts the host's `~/.aws` read-only at `/home/storm/.aws`. It is mounted there — the `storm` user's home — rather than `/root`, because the worker JVM runs as the `storm` user, so that is where the AWS SDK's default `~/.aws` lookup resolves. Make sure the profile exists in your `~/.aws/credentials` (and `~/.aws/config` for region / SSO / role).
 
 Then download and build the Docker images:
 
@@ -102,9 +140,9 @@ docker compose run --rm news-crawler \
 
 After 1-2 minutes if everything is up, connect to OpenSearch on port [9200](http://localhost:9200/) or the OpenSearch dashboards on port [5601](http://localhost:5601/).
 
-For inspecting the worker log files:
+For inspecting the worker log files (the container name matches `container_name:` for the `storm-supervisor` service in [docker-compose.yaml](docker-compose.yaml)):
 ```
-docker exec storm-supervisor-news-crawl /bin/bash -c 'cat /logs/workers-artifacts/*/*/worker.log'
+docker exec storm-supervisor-news-crawl-production /bin/bash -c 'cat /logs/workers-artifacts/*/*/worker.log'
 ```
 
 To stop the topology:
@@ -121,10 +159,26 @@ $> storm kill NewsCrawl
 
 ## Note for developers
 
+Requires **JDK 17+** (see [.java-version](.java-version)). Common commands:
+
+```
+mvn clean package                         # build the shaded uberjar → target/crawler-3.6.0.jar
+mvn test                                  # run all JUnit tests
+mvn test -Dtest=NewsSiteMapParserTest     # run a single test class
+```
+
+Code style is [google-java-format](https://github.com/google/google-java-format) (AOSP profile), enforced in CI by the Cosium `git-code-format-maven-plugin`. The plugin is gated behind the `skip.format.code` property (default `true`), so you must pass `-Dskip.format.code=false` to run it locally.
+
 Please format your code before submitting a PR with
 
 ```
 mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false
+```
+
+To only check formatting (as CI does), without modifying files:
+
+```
+mvn git-code-format:validate-code-format -Dgcf.globPattern="**/*" -Dskip.format.code=false
 ```
 
 You can enable pre-commit format hooks by running:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Two indexes / stores are involved:
 - **OpenSearch** holds the *URL status index*: every known URL and its state (`DISCOVERED`, `FETCHED`, `REDIRECTION`, `ERROR`). This is the crawler's memory of what to fetch next.
 - **WARC files** on local disk (`warc.dir`) hold the actual fetched content — this is the output shipped to Common Crawl.
 
-The production crawl ([`CrawlTopology`](src/main/java/org/commoncrawl/stormcrawler/news/CrawlTopology.java)) is a Storm pipeline:
+The production crawl is a Storm pipeline defined primarily in [`conf/crawler.flux`](conf/crawler.flux) (the main topology, launched via [Storm Flux](https://storm.apache.org/releases/2.8.8/flux.html)). A functionally-equivalent Java implementation of the same pipeline is provided in [`CrawlTopology`](src/main/java/org/commoncrawl/stormcrawler/news/CrawlTopology.java). Either way the DAG is the same:
 
 ```
 seeds/feeds.txt
@@ -42,33 +42,51 @@ The crawler relies on [RSS](https://en.wikipedia.org/wiki/RSS)/[Atom](https://en
 
 ## Configuration
 
-The default configuration should work out-of-the-box. The only thing to do is to configure the user agent properties send in the HTTP request header. Open the file `conf/crawler-conf.yaml` in an editor and fill in the values for `http.agent.name` and all further properties starting with the `http.agent.` prefix.
+The default configuration works out-of-the-box for a local test crawl. The **only mandatory change** is the HTTP user agent — news sites reject requests without a real `User-Agent`. Open `conf/crawler-conf.yaml` and fill in `http.agent.name` and the other `http.agent.*` properties (`version`, `url`, `email`).
+
+The crawl is configured through a handful of files under [`conf/`](./conf/), layered on top of StormCrawler's built-in `crawler-default.yaml` (later files override earlier ones):
+
+| File | What it configures |
+| --- | --- |
+| [`crawler-conf.yaml`](conf/crawler-conf.yaml) | Main crawler config: HTTP agent (`http.agent.*`), fetch parallelism, timeouts, content-size limits, and the `warc.*` keys (`warc.dir`, `warc.rotation.policy.max-mb` / `max-minutes`). |
+| [`opensearch-conf.yaml`](conf/opensearch-conf.yaml) | OpenSearch cluster addresses and the status-index / indexer settings. |
+| [`crawler.flux`](conf/crawler.flux) | The main topology definition itself (spouts, bolts, streams) **and** the WARC output settings — see below. Includes the two files above. |
+| [`bootstrap-conf.yaml`](conf/bootstrap-conf.yaml) | Config for the [bootstrap topology](#bootstrap-discovering-feeds-and-sitemaps); sets a distinct WARC directory (`/data/warc/bootstrap`) and a more conservative `fetcher.server.delay`. |
+
+### WARC output settings
+
+Where WARC files are written and how they rotate is configured **differently** depending on which topology you launch:
+
+- **Flux (`crawler.flux`) — hardcoded in the component definitions.** The output path is `WARCFileNameFormat.withPath("/data/warc")` and rotation is `1024 MB` / `1440 minutes` in `WARCFileRotationPolicy`. These **ignore** the `warc.*` config keys, so to change them you must edit `crawler.flux` directly. Also fill in the placeholder `WARCInfo` header values (`http-header-user-agent`, `http-header-from`, `operator`, `robots`), which ship as `"..."`.
+- **Java (`CrawlTopology`) — read from config.** The output path comes from `warc.dir` (default `/data/warc`) and rotation from `warc.rotation.policy.max-mb` / `warc.rotation.policy.max-minutes` in `crawler-conf.yaml`; the WARC header fields are derived from the `http.agent.*` values at runtime.
+
+In both cases the WARC output directory must exist before you start the crawl.
 
 
 ## Run the crawl
 
-Generate an uberjar:
+Once the configuration is in place, generate the uberjar:
 ``` sh
 mvn clean package
 ```
 
-And run ...
+The main news crawler topology is defined in [`conf/crawler.flux`](./conf/crawler.flux) and launched via [Storm Flux](https://storm.apache.org/releases/2.8.8/flux.html) — this is also the default entry point of the shaded jar (its manifest `mainClass` is `org.apache.storm.flux.Flux`).
+
+For a quick local smoke test you can instead run the equivalent Java topology [`CrawlTopology`](src/main/java/org/commoncrawl/stormcrawler/news/CrawlTopology.java) in local mode. Note the `--` separator: it overrides the manifest's default Flux main class so the named class runs instead.
 ``` sh
 storm local target/crawler-3.6.0.jar --local-ttl 60 -- org.commoncrawl.stormcrawler.news.CrawlTopology -conf $PWD/conf/opensearch-conf.yaml -conf $PWD/conf/crawler-conf.yaml $PWD/seeds/ feeds.txt
 ```
 
 This will launch the crawl topology in local mode for 60 seconds. It will also "inject" all URLs found in the file `./seeds/feeds.txt` in the status index. The URLs point to news feeds and sitemaps from which links to news articles are extracted and fetched. The topology will create WARC files in the directory specified in the configuration under the key `warc.dir`. This directory must be created beforehand.
 
-Of course, it's also possible to add (or remove) the seeds (feeds and sitemaps) using the OpenSearch API. In this case, the can topology can be run without the last two arguments.
+Of course, it's also possible to add (or remove) the seeds (feeds and sitemaps) using the OpenSearch API. In this case, the topology can be run without the last two arguments.
 
-Alternatively, the topology can be run from the [crawler.flux](./conf/crawler.flux), please see the [Storm Flux documentation](https://storm.apache.org/releases/2.8.8/flux.html). Make sure to adapt the Flux definition to your needs!
-
-In production, you should use `storm jar ...` to run the topology in distributed mode and continuously (no time limit) including the Storm UI and logging.
+In production, you should use `storm jar ...` to run the topology in distributed mode and continuously (no time limit) including the Storm UI and logging (see the Docker Compose section below for the exact Flux and Java commands).
 
 
 ## Bootstrap: discovering feeds and sitemaps
 
-The production crawl assumes its seeds are *already known* to be feeds or news sitemaps. When you only have a list of candidate URLs (e.g. news site home pages) and don't yet know which of them expose a feed or a Google News sitemap, run the **bootstrap topology** first.
+The news crawl assumes its seeds are *already known* to be feeds or news sitemaps. When you only have a list of candidate URLs (e.g. news site home pages) and don't yet know which of them expose a feed or a Google News sitemap, run the **bootstrap topology** first.
 
 [`BootstrapTopology`](src/main/java/org/commoncrawl/stormcrawler/news/bootstrap/BootstrapTopology.java) reuses the same fetch skeleton but replaces the *parser* bolts with *detector* bolts — [`NewsSiteMapDetectorBolt`](src/main/java/org/commoncrawl/stormcrawler/news/bootstrap/NewsSiteMapDetectorBolt.java) and [`FeedDetectorBolt`](src/main/java/org/commoncrawl/stormcrawler/news/FeedDetectorBolt.java) — which classify a fetched URL by its content/`Content-Type` instead of extracting article links from it. The detected feeds and sitemaps can then be used as seeds for the production crawl above.
 
@@ -123,15 +141,15 @@ Wait until the containers are running, then initialize the OpenSearch index and 
 
 NOTE:
 - This will delete existing indexes!
-- Make sure that the OpenSearch port 9200 is not already in use or mapped by a running OpenSearch instance. Otherwise OpenSearch commands may affect the running instance!
+- Make sure that the OpenSearch port 9200 is not already in use or mapped by a running OpenSearch instance. Otherwise, OpenSearch commands may affect the running instance!
 
 
-To launch the topology using [Storm Flux](https://storm.apache.org/releases/2.8.8/flux.html):
+Submit the topology from the `news-crawler` service. The main path uses [Storm Flux](https://storm.apache.org/releases/2.8.8/flux.html) with `conf/crawler.flux`:
 ```
 docker compose run --rm news-crawler \
     storm jar lib/crawler.jar org.apache.storm.flux.Flux --remote /news-crawler/conf/crawler.flux
 ```
-Or using the Java topology:
+Or run the equivalent Java topology (the `--` separator overrides the manifest's default Flux main class):
 ```
 docker compose run --rm news-crawler \
     storm jar lib/crawler.jar -- org.commoncrawl.stormcrawler.news.CrawlTopology \
@@ -142,7 +160,7 @@ After 1-2 minutes if everything is up, connect to OpenSearch on port [9200](http
 
 For inspecting the worker log files (the container name matches `container_name:` for the `storm-supervisor` service in [docker-compose.yaml](docker-compose.yaml)):
 ```
-docker exec storm-supervisor-news-crawl-production /bin/bash -c 'cat /logs/workers-artifacts/*/*/worker.log'
+docker exec storm-supervisor-news-crawl /bin/bash -c 'cat /logs/workers-artifacts/*/*/worker.log'
 ```
 
 To stop the topology:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,9 +53,15 @@ services:
       - opensearch
     # - the WARC output folder
     # - and the seed folder
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-cc}
+      - AWS_REGION=${AWS_REGION:-us-east-1}   # or rely on region= in the profile
     volumes:
       - ${WARCOUTPUT:-./warcdata}:/data/warc
       - ${SEEDDIR:-./seeds}:/data/seeds
+      # Worker JVMs run as the "storm" user (home /home/storm), so mount the host's ~/.aws
+      # at the storm user's home for the AWS SDK's default ~/.aws lookup to find it.
+      - ${HOME}/.aws:/home/storm/.aws:ro
     restart: always
 
   # - the Storm UI provides diagnostics about the Storm cluster
@@ -82,6 +88,12 @@ services:
       - "OPENSEARCH_JAVA_OPTS=-Xms4G -Xmx4G"
       - plugins.security.disabled=true
       - "DISABLE_INSTALL_DEMO_CONFIG=true"
+    networks:
+      # conf/opensearch-conf.yaml addresses the cluster as "opensearch-news-crawl" (the
+      # production DNS name); expose that as an alias so those addresses resolve in Compose too.
+      default:
+        aliases:
+          - opensearch-news-crawl
     volumes:
       - ${OPENSEARCHDATA:-./opensearchdata}:/usr/share/opensearch/data
     ulimits:
@@ -102,7 +114,7 @@ services:
     expose:
       - "5601"
     environment:
-      - 'OPENSEARCH_HOSTS=["http://opensearch-news-crawl:9200"]'
+      - 'OPENSEARCH_HOSTS=["http://opensearch:9200"]'
       - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" # disables security dashboards plugin in OpenSearch Dashboards
 
   # - to launch a topology

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,15 +53,10 @@ services:
       - opensearch
     # - the WARC output folder
     # - and the seed folder
-    environment:
-      - AWS_PROFILE=${AWS_PROFILE:-cc}
-      - AWS_REGION=${AWS_REGION:-us-east-1}   # or rely on region= in the profile
+
     volumes:
       - ${WARCOUTPUT:-./warcdata}:/data/warc
       - ${SEEDDIR:-./seeds}:/data/seeds
-      # Worker JVMs run as the "storm" user (home /home/storm), so mount the host's ~/.aws
-      # at the storm user's home for the AWS SDK's default ~/.aws lookup to find it.
-      - ${HOME}/.aws:/home/storm/.aws:ro
     restart: always
 
   # - the Storm UI provides diagnostics about the Storm cluster

--- a/src/main/java/org/commoncrawl/stormcrawler/news/CrawlTopology.java
+++ b/src/main/java/org/commoncrawl/stormcrawler/news/CrawlTopology.java
@@ -126,7 +126,7 @@ public class CrawlTopology extends ConfigurableTopology {
         fileNameFormat.withPrefix(filePrefix);
 
         Map<String, String> fields = new LinkedHashMap<>();
-        fields.put("software", "StormCrawler 2.10 https://stormcrawler.net/");
+        fields.put("software", "StormCrawler 3.6.0 https://stormcrawler.net/");
         fields.put("description", "News crawl for Common Crawl");
         String userAgent = AbstractHttpProtocol.getAgentString(getConf());
         fields.put("http-header-user-agent", userAgent);


### PR DESCRIPTION
I've brush the documentation up a bit by adding more detailed information on how to run the news crawl and having more details on which files are used and for what. 

In addition this include some notes on how to use the FastURL deny list via S3 and a small change updating a stale `StormCrawler 2.10 version` mentioned in the WARC Bolt. 