### PR TITLE
feat: retire dead ephemeral sitemaps via NewsSitemapScheduler (#40)

### DIFF
--- a/conf/crawler-conf.yaml
+++ b/conf/crawler-conf.yaml
@@ -129,7 +129,10 @@ config:
   fetcher.max.urls.in.queues: 6000
 
   # fetch Scheduler implementation
-  scheduler.class: "org.apache.stormcrawler.persistence.AdaptiveScheduler"
+  # NewsSitemapScheduler extends AdaptiveScheduler and additionally retires dead ephemeral
+  # sitemaps (issue commoncrawl/news-crawl#40). Revert to the plain AdaptiveScheduler to disable.
+  scheduler.class: "org.commoncrawl.stormcrawler.news.NewsSitemapScheduler"
+  # scheduler.class: "org.apache.stormcrawler.persistence.AdaptiveScheduler"
   # AdaptiveScheduler properties
   scheduler.adaptive.setLastModified: true
   # frequently changing feeds or news sitemaps are refetched after 90 min.
@@ -138,6 +141,9 @@ config:
   scheduler.adaptive.fetchInterval.max: 129600
   scheduler.adaptive.fetchInterval.rate.incr: .5
   scheduler.adaptive.fetchInterval.rate.decr: .2
+  # NewsSitemapScheduler: tombstone a sitemap not modified for at least this many minutes
+  # that also yields no recent news (numLinks == 0). 259200 min = 180 days.
+  scheduler.sitemap.ephemeral.staleInterval: 259200
 
   # AdaptiveScheduler only handles successful re-fetches (HTTP 200 or 304 not modified),
   # all others are delegated to DefaultScheduler

--- a/src/main/java/org/commoncrawl/stormcrawler/news/NewsSiteMapParserBolt.java
+++ b/src/main/java/org/commoncrawl/stormcrawler/news/NewsSiteMapParserBolt.java
@@ -88,6 +88,9 @@ public class NewsSiteMapParserBolt extends SiteMapParserBolt {
      */
     public static final String isSitemapVerifiedKey = "isSitemapVerified";
 
+    /** Number of (recent) links extracted from the sitemap on the last parse. */
+    public static final String numLinksKey = "numLinks";
+
     private static final org.slf4j.Logger LOG =
             LoggerFactory.getLogger(NewsSiteMapParserBolt.class);
 
@@ -214,7 +217,7 @@ public class NewsSiteMapParserBolt extends SiteMapParserBolt {
             // its status
             metadata.setValue(Constants.STATUS_ERROR_SOURCE, "sitemap parsing");
             metadata.setValue(Constants.STATUS_ERROR_MESSAGE, errorMessage);
-            metadata.remove("numLinks");
+            metadata.remove(numLinksKey);
             collector.emit(
                     Constants.StatusStreamName, tuple, new Values(url, metadata, Status.ERROR));
             collector.ack(tuple);
@@ -234,7 +237,7 @@ public class NewsSiteMapParserBolt extends SiteMapParserBolt {
             LOG.error(errorMessage);
             metadata.setValue(Constants.STATUS_ERROR_SOURCE, "content filtering");
             metadata.setValue(Constants.STATUS_ERROR_MESSAGE, errorMessage);
-            metadata.remove("numLinks");
+            metadata.remove(numLinksKey);
             collector.emit(StatusStreamName, tuple, new Values(url, metadata, Status.ERROR));
             collector.ack(tuple);
             return;
@@ -263,7 +266,7 @@ public class NewsSiteMapParserBolt extends SiteMapParserBolt {
         }
 
         // track the number of links found in the sitemap
-        metadata.setValue("numLinks", String.valueOf(outlinks.size()));
+        metadata.setValue(numLinksKey, String.valueOf(outlinks.size()));
 
         // marking the main URL as successfully fetched
         collector.emit(

--- a/src/main/java/org/commoncrawl/stormcrawler/news/NewsSitemapScheduler.java
+++ b/src/main/java/org/commoncrawl/stormcrawler/news/NewsSitemapScheduler.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commoncrawl.stormcrawler.news;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.bolt.SiteMapParserBolt;
+import org.apache.stormcrawler.persistence.AdaptiveScheduler;
+import org.apache.stormcrawler.persistence.Status;
+import org.apache.stormcrawler.util.ConfUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link AdaptiveScheduler} that additionally retires ephemeral sitemaps. Sites that mint endless
+ * unique sitemap URLs (dated, counter- or hash-based) would otherwise be revisited forever; this
+ * scheduler tombstones such a sitemap once it has both stopped changing and stopped yielding recent
+ * news, so it is never selected again.
+ *
+ * <p>A {@link Status#FETCHED} sitemap is tombstoned when both conditions hold:
+ *
+ * <ul>
+ *   <li>its content has not been modified for at least a configurable interval ({@value
+ *       #STALE_INTERVAL_PARAM}, in minutes), based on the {@code signatureChangeDate} metadata
+ *       written by {@link AdaptiveScheduler}; and
+ *   <li>it yields no recent news, i.e. {@code numLinks == 0}, set by {@link NewsSiteMapParserBolt}.
+ * </ul>
+ *
+ * <p>Because a sitemap that still changes keeps its signature moving, the decision is based on
+ * change, not on URL shape. Tombstoning returns {@link Optional#empty()} (no next-fetch date);
+ * every other case is delegated to {@link AdaptiveScheduler}.
+ */
+public class NewsSitemapScheduler extends AdaptiveScheduler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NewsSitemapScheduler.class);
+
+    /** Minimum time (minutes) a sitemap must be unmodified before it may be tombstoned. */
+    public static final String STALE_INTERVAL_PARAM = "scheduler.sitemap.ephemeral.staleInterval";
+
+    /** Default staleness interval: 180 days (in minutes). */
+    private static final int DEFAULT_STALE_INTERVAL_MINUTES = 180 * 24 * 60;
+
+    private long staleMillis;
+
+    @Override
+    public void init(Map<String, Object> stormConf) {
+        super.init(stormConf);
+        int minutes =
+                ConfUtils.getInt(stormConf, STALE_INTERVAL_PARAM, DEFAULT_STALE_INTERVAL_MINUTES);
+        this.staleMillis = minutes * 60_000L;
+        LOG.info(
+                "NewsSitemapScheduler: tombstone sitemaps not modified for > {} min with numLinks=0",
+                minutes);
+    }
+
+    @Override
+    public Optional<Date> schedule(Status status, Metadata metadata) {
+        if (isDeadEphemeralSitemap(status, metadata, staleMillis)) {
+            // tombstone: no next-fetch date
+            return Optional.empty();
+        }
+        return super.schedule(status, metadata);
+    }
+
+    /** Static and package-private so the predicate can be unit-tested without the superclass. */
+    static boolean isDeadEphemeralSitemap(Status status, Metadata metadata, long staleMillis) {
+        if (status != Status.FETCHED || !isSitemap(metadata)) {
+            return false;
+        }
+        return notModifiedLongerThan(metadata, staleMillis) && noRecentNews(metadata);
+    }
+
+    private static boolean isSitemap(Metadata m) {
+        return Boolean.parseBoolean(m.getFirstValue(SiteMapParserBolt.isSitemapKey))
+                || Boolean.parseBoolean(m.getFirstValue(NewsSiteMapParserBolt.isSitemapNewsKey))
+                || Boolean.parseBoolean(m.getFirstValue(NewsSiteMapParserBolt.isSitemapIndexKey))
+                || Boolean.parseBoolean(
+                        m.getFirstValue(NewsSiteMapParserBolt.isSitemapVerifiedKey));
+    }
+
+    /** {@code numLinks == 0} means the last parse found no recent news links. */
+    private static boolean noRecentNews(Metadata m) {
+        return "0".equals(m.getFirstValue(NewsSiteMapParserBolt.numLinksKey));
+    }
+
+    /**
+     * True when the sitemap's content has not been modified for longer than {@code millis}, based
+     * on the {@code signatureChangeDate} metadata set by {@link AdaptiveScheduler}.
+     */
+    private static boolean notModifiedLongerThan(Metadata m, long millis) {
+        String changed = m.getFirstValue(AdaptiveScheduler.SIGNATURE_MODIFIED_KEY);
+        if (changed == null) {
+            return false; // no change history yet -> never tombstone (safe default)
+        }
+        try {
+            long changedAt = Instant.parse(changed).toEpochMilli();
+            return (System.currentTimeMillis() - changedAt) > millis;
+        } catch (Exception e) {
+            return false; // unparseable date -> treat as not stale (never tombstone)
+        }
+    }
+}

--- a/src/test/java/org/commoncrawl/stormcrawler/news/NewsSitemapSchedulerTest.java
+++ b/src/test/java/org/commoncrawl/stormcrawler/news/NewsSitemapSchedulerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commoncrawl.stormcrawler.news;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.bolt.SiteMapParserBolt;
+import org.apache.stormcrawler.persistence.AdaptiveScheduler;
+import org.apache.stormcrawler.persistence.Status;
+import org.junit.Test;
+
+/**
+ * Tests the tombstone predicate of {@link NewsSitemapScheduler}: a fetched sitemap is retired only
+ * when it has not been modified long enough <em>and</em> yields no recent news. Every other case
+ * falls through to the normal adaptive schedule.
+ */
+public class NewsSitemapSchedulerTest {
+
+    private static final long STALE_30D = 30L * 24 * 3600 * 1000;
+
+    private static Metadata sitemap(String numLinks, String signatureChangeDate) {
+        Metadata m = new Metadata();
+        m.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        if (numLinks != null) {
+            m.setValue(NewsSiteMapParserBolt.numLinksKey, numLinks);
+        }
+        if (signatureChangeDate != null) {
+            m.setValue(AdaptiveScheduler.SIGNATURE_MODIFIED_KEY, signatureChangeDate);
+        }
+        return m;
+    }
+
+    private static String daysAgo(int days) {
+        return Instant.ofEpochMilli(System.currentTimeMillis() - days * 24L * 3600 * 1000)
+                .toString();
+    }
+
+    private static boolean dead(Status status, Metadata m) {
+        return NewsSitemapScheduler.isDeadEphemeralSitemap(status, m, STALE_30D);
+    }
+
+    /** Unmodified long enough + no recent news => tombstone. */
+    @Test
+    public void staleAndNoNews_isTombstoned() {
+        assertTrue(dead(Status.FETCHED, sitemap("0", daysAgo(200))));
+    }
+
+    /** Still producing news => kept, even if unmodified for a long time. */
+    @Test
+    public void hasRecentNews_notTombstoned() {
+        assertFalse(dead(Status.FETCHED, sitemap("5", daysAgo(200))));
+    }
+
+    /** Modified recently => not stale => kept. */
+    @Test
+    public void recentlyModified_notTombstoned() {
+        assertFalse(dead(Status.FETCHED, sitemap("0", daysAgo(1))));
+    }
+
+    /** No change history yet => never tombstone (safe default). */
+    @Test
+    public void noChangeHistory_notTombstoned() {
+        assertFalse(dead(Status.FETCHED, sitemap("0", null)));
+    }
+
+    /** Non-sitemap docs are out of scope. */
+    @Test
+    public void nonSitemap_notTombstoned() {
+        Metadata m = new Metadata();
+        m.setValue(NewsSiteMapParserBolt.numLinksKey, "0");
+        m.setValue(AdaptiveScheduler.SIGNATURE_MODIFIED_KEY, daysAgo(200));
+        assertFalse(dead(Status.FETCHED, m));
+    }
+
+    /** Only successful re-fetches are considered. */
+    @Test
+    public void notFetched_notTombstoned() {
+        assertFalse(dead(Status.DISCOVERED, sitemap("0", daysAgo(200))));
+    }
+}


### PR DESCRIPTION
# Retire dead ephemeral sitemaps via the scheduler ([#40](https://github.com/commoncrawl/news-crawl/issues/40))

Supersedes the earlier pattern-bolt prototype and the staging PR in `news-crawl-production#6`.

## Summary

News sites mint sitemaps with unique, rotating URLs (timestamps, counters, UUIDs, hashes) that never
disappear, so the frontier fills with dead sitemaps that keep getting re-checked and starve fresh
article crawling.

`NewsSitemapScheduler` extends the existing `AdaptiveScheduler` and lets its back-off run all the way
to *never* for a fetched sitemap that is provably dead: its content has not been modified for a
configurable interval **and** it yields no recent news. Removal is a reschedule (tombstone), so it is
sticky against re-listing and needs no separate cleanup job on the large status index.

It adds **no new metadata field, no pattern file, nothing baked into the jar** — it reuses two signals
the crawler already computes: the content's last-change time (`signatureChangeDate`) and the count of
recent news links (`numLinks`).

## Why not filter by URL shape

Names lie: this month's live sitemap and a five-year-old dead one share the same shape, and a freshly
minted `uuid.xml` looks like a dead one. Dropping on shape either misses the bad ones or silently loses
**live** sitemaps, and a site escapes by changing its naming. The discriminator is whether a sitemap
still **changes** — a content signal that is already tracked.

## What it does

When a fetched sitemap has not changed for the configured staleness interval **and** has no recent
news links, it is given no next-fetch date, so it is never re-selected. A sitemap that still changes
is never tombstoned; everything else keeps the normal adaptive schedule.

## Files

| File | |
|---|---|
| `src/main/java/…/news/NewsSitemapScheduler.java` | the scheduler (new) |
| `src/test/java/…/news/NewsSitemapSchedulerTest.java` | 6 unit tests (new) |
| `src/main/java/…/news/NewsSiteMapParserBolt.java` | add `numLinksKey` constant, use it |
| `conf/crawler-conf.yaml` | set `scheduler.class`, add `scheduler.sitemap.ephemeral.staleInterval` |

## Config

```yaml
scheduler.class: "org.commoncrawl.stormcrawler.news.NewsSitemapScheduler"
scheduler.sitemap.ephemeral.staleInterval: 259200   # minutes not modified => stale (= 180 days)
```
Revert `scheduler.class` to `org.apache.stormcrawler.persistence.AdaptiveScheduler` to disable.

## Testing

`mvn test -Dtest=NewsSitemapSchedulerTest` — 6 tests: stale + no-news → tombstone; still-has-news /
recently-modified / non-sitemap / not-fetched / no-change-history → kept. Formatted with
`mvn git-code-format:format-code`.

## Scope & threat model

This is an efficiency layer for the honest-but-messy majority — real news sites that generate
dated/rotating sitemaps that genuinely go stale. It is **not** an adversary defence: a site that makes
identical content look new (e.g. `?version=N` daily) keeps looking modified and defeats any content
signal — as would any shape-based approach. The robust boundary for that is *who* we crawl (rank /
quality / allowlist), which today is the curated seed list; there is no runtime rank budget here. This
change sits inside that boundary and only reduces wasted re-checks.

## Follow-ups (not here)

- Host-level offender score (per-host ephemeral rate as a rank/quality signal) — adversary-resistant.
- Rank/quality gate on sitemap discovery, since `sitemap.discovery` probes any host.
