### PR TITLE
Add specific commands to manage the status index filtered resources 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ $> bin/status aggregate_status
 
 Run `bin/status` without arguments to see the full list of sub-commands (each sub-command is a function inside the script). Pass `-C` to colorize the JSON output.
 
+For managing filtered resources in the statux index, see [docs/status-sources.md](./docs/status-sources.md).
+
 
 ## Run Crawl with Docker Compose
 

--- a/bin/status
+++ b/bin/status
@@ -81,6 +81,40 @@ function ____show_help() {
     echo "      refetch), error causes, and the most recently fetched URL"
     echo "      Example usage:"
     echo "        status domain_report example.com www.example.org"
+    echo " domain_sources <HOST/DOMAIN>..."
+    echo "      list all feeds and sitemaps (the crawl sources) of a host/domain"
+    echo "      with their status and metadata: type, fetch status, next/last"
+    echo "      fetch, fetch interval, number of links, HTTP status, Last-Modified,"
+    echo "      error cause or redirect target. URLs which look like a feed or"
+    echo "      sitemap but carry no flag (e.g. seeds rejected by the pre-filter"
+    echo "      before their first fetch) are listed as type \"unflagged\"."
+    echo "      Example usage:"
+    echo "        status domain_sources example.com"
+    echo " refetch_sources [search|count|update] <HOST/DOMAIN> [<URL-REGEXP> [<TYPES>]]"
+    echo "      re-arm the flagged feeds and sitemaps of a host/domain so that they are"
+    echo "      fetched again: status is reset to DISCOVERED, nextFetchDate set to"
+    echo "      \$REFETCH_DATE (default: now), cached validators (Last-Modified, ETag) and"
+    echo "      error cause removed. Use search/count first to inspect the affected"
+    echo "      documents. Note that URLs of a domain are fetched in nextFetchDate order:"
+    echo "      set REFETCH_DATE to a past date (e.g. 2000-01-01) to put the sources ahead"
+    echo "      of a large backlog of older DISCOVERED URLs."
+    echo "      URL-REGEXP (default .*, quote it!) must match the whole URL. TYPES is a comma-"
+    echo "      separated list of feed, sitemap, sitemap-news, sitemap-index, sitemap-verified,"
+    echo "      unflagged (default: all flagged types, i.e. without unflagged)."
+    echo "      Example usage:"
+    echo "        status refetch_sources search brighteon.com"
+    echo "        status refetch_sources update brighteon.com '.*/sitemap\\.xml'"
+    echo "        status refetch_sources update example.com '.*' feed,sitemap-news"
+    echo "        REFETCH_DATE=2000-01-01 status refetch_sources update brighteon.com '.*/sitemap\\.xml'"
+    echo " filtered_sources [search|count|update] <HOST/DOMAIN> [<URL-REGEXP> [<TYPES>]]"
+    echo "      feeds and sitemaps of a host/domain rejected by the pre-filter (error"
+    echo "      cause \"Filtered\"), including unflagged look-alikes (seeds blocked before"
+    echo "      their first fetch). \"update\" re-arms them like refetch_sources does."
+    echo "      URL-REGEXP and TYPES as for refetch_sources (default TYPES: all)."
+    echo "      Typical use after removing a host/domain from the fast URL filter:"
+    echo "        status filtered_sources search example.com"
+    echo "        status filtered_sources update example.com"
+    echo "        status filtered_sources update feedburner.com '.*' feed"
     echo
     echo " next_fetch [search|count] [<PAGE> [<SIZE>]]"
     echo "      documents to be fetched next"
@@ -537,6 +571,248 @@ function __domain_report () {
     done
 }
 
+# feeds and sitemaps of a single host/domain, with metadata
+#
+# A document is a crawl source if any of the persisted boolean flags is "true" (see
+# metadata.persist in crawler-conf.yaml). The flags are matched against the string
+# "true" rather than by mere existence because NewsSiteMapParserBolt explicitly writes
+# "false" when it re-classifies a sitemap (e.g. isSitemapNews=false on a sitemap index).
+#
+# StormCrawler's Metadata class lowercases all keys, so the flags configured as
+# "isFeed", "isSitemapNews", ... in crawler-conf.yaml are stored as "isfeed",
+# "issitemapnews", ... in the index. Keys containing a dot are stored with the dot
+# escaped as %2E, and every metadata value is an array (hence the [0] in jq below).
+#
+# ____sources_query DOMAIN URLREGEXP TYPES [EXTRAFILTER]
+#   boolean query selecting the sources of DOMAIN whose URL matches URLREGEXP (".*" for
+#   all) and whose type is one of TYPES (comma-separated: feed, sitemap, sitemap-news,
+#   sitemap-index, sitemap-verified, unflagged). Type "unflagged" selects URLs which
+#   merely look like a feed or sitemap (containing sitemap, rss, feed or atom, not
+#   followed by a letter, so that "feeding" or "atomic" do not match): a seed rejected by PreFilterBolt
+#   (error.cause=Filtered) before its first successful fetch never received a flag, yet
+#   it is exactly the document to reset once the host is unblocked. The name-based match
+#   is a heuristic; the URL column tells. When "unflagged" is requested, documents
+#   carrying one of the flags *not* requested are excluded, so that e.g. "feed,unflagged"
+#   does not re-arm sitemaps named sitemap.xml. EXTRAFILTER is an additional JSON filter
+#   clause (e.g. a term on the error cause).
+SOURCE_TYPES_FLAGGED="feed,sitemap,sitemap-news,sitemap-index,sitemap-verified"
+SOURCE_TYPES_ALL="$SOURCE_TYPES_FLAGGED,unflagged"
+function ____source_type_flag () {
+    case "$1" in
+        feed )             echo isfeed ;;
+        sitemap )          echo issitemap ;;
+        sitemap-news )     echo issitemapnews ;;
+        sitemap-index )    echo issitemapindex ;;
+        sitemap-verified ) echo issitemapverified ;;
+        unflagged )        echo "" ;;
+        * ) echo "Unknown source type: $1 (expected one of $SOURCE_TYPES_ALL)" >&2; exit 1 ;;
+    esac
+}
+function ____check_source_types () {
+    for T in ${1//,/ }; do
+        ____source_type_flag "$T" > /dev/null
+    done
+}
+function ____sources_query () {
+    DOMAIN="$1"
+    URLREGEXP="${2:-.*}"
+    TYPES="${3:-$SOURCE_TYPES_ALL}"
+    # the regexp is embedded in a JSON string: escape backslashes and double quotes
+    URLREGEXP="${URLREGEXP//\\/\\\\}"
+    URLREGEXP="${URLREGEXP//\"/\\\"}"
+    EXTRAFILTER=""
+    [ -n "$4" ] && EXTRAFILTER=",
+                $4"
+    SHOULD=""
+    MUSTNOT=""
+    UNFLAGGED=false
+    for T in ${TYPES//,/ }; do
+        FLAG="$(____source_type_flag "$T")"
+        if [ -z "$FLAG" ]; then
+            UNFLAGGED=true
+            SHOULD="$SHOULD"',
+                { "regexp": { "url": { "value": ".*(sitemaps?|rss|feeds?|atom)([^a-zA-Z].*)?",
+                                       "case_insensitive": true }}}'
+        else
+            SHOULD="$SHOULD"',
+                { "term": { "metadata.'"$FLAG"'": "true" }}'
+        fi
+    done
+    if $UNFLAGGED; then
+        for T in ${SOURCE_TYPES_FLAGGED//,/ }; do
+            case ",$TYPES," in
+                *,$T,* ) ;;
+                * ) MUSTNOT="$MUSTNOT"',
+                { "term": { "metadata.'"$(____source_type_flag "$T")"'": "true" }}' ;;
+            esac
+        done
+    fi
+    echo '"bool": {
+            "filter": [
+                { "term": { "key": "'"$DOMAIN"'" }},
+                { "regexp": { "url": { "value": "'"$URLREGEXP"'" }}}'"$EXTRAFILTER"'
+            ],
+            "should": ['"${SHOULD#,}"'
+            ],
+            "minimum_should_match": 1,
+            "must_not": ['"${MUSTNOT#,}"'
+            ]
+        }'
+}
+
+# search the sources of a host/domain (routed: one shard) and print them as a TSV table
+#
+# At most 10000 documents (index.max_result_window) are shown. Feeds and news/index/
+# verified sitemaps are sorted first so that, if the cap is hit, only plain (robots.txt
+# discovered) sitemaps and unflagged candidates are cut off. track_total_hits makes the
+# reported total exact (otherwise OpenSearch stops counting at 10000 as well).
+function ____sources_table () {
+    DOMAIN="$1"
+    QUERY="$2"
+    $SHOW_COMMAND
+    $CURL -XGET $ES_STATUS_URL'/_search?pretty&routing='"$DOMAIN" --data '{
+    "size": 10000,
+    "track_total_hits": true,
+    "_source": ["url", "status", "nextFetchDate", "metadata"],
+    "query": { '"$QUERY"' },
+    "sort": [
+        { "metadata.isfeed":            { "order": "desc", "missing": "_last", "unmapped_type": "keyword" }},
+        { "metadata.issitemapnews":     { "order": "desc", "missing": "_last", "unmapped_type": "keyword" }},
+        { "metadata.issitemapindex":    { "order": "desc", "missing": "_last", "unmapped_type": "keyword" }},
+        { "metadata.issitemapverified": { "order": "desc", "missing": "_last", "unmapped_type": "keyword" }},
+        { "metadata.issitemap":         { "order": "desc", "missing": "_last", "unmapped_type": "keyword" }},
+        { "url": "asc" }
+    ]
+}' | jq --raw-output '
+        def meta($k): ((._source.metadata[$k] // [])[0]) // "-";
+        # all values, for keys which are appended to (PreFilterBolt adds "Filtered" to error.cause)
+        def metas($k): ((._source.metadata[$k] // []) | join(",")) | if . == "" then "-" else . end;
+        def istrue($k): (._source.metadata[$k] // [])[0] == "true";
+        # precedence matters only for the rare document carrying several flags
+        def srctype:
+            if istrue("isfeed") then "feed"
+            elif istrue("issitemapnews") then "sitemap-news"
+            elif istrue("issitemapindex") then "sitemap-index"
+            elif istrue("issitemapverified") then "sitemap-verified"
+            elif istrue("issitemap") then "sitemap"
+            else "unflagged" end;
+        def epoch_ms_to_date:
+            if . == "-" then "-" else (tonumber / 1000 | floor | todate) end;
+        [.hits.hits[] | {
+            type: srctype,
+            status: ._source.status,
+            next: (._source.nextFetchDate // "-"),
+            last: (meta("protocol%2E_request%2Etime_") | epoch_ms_to_date),
+            interval: meta("fetchinterval"),
+            links: meta("numlinks"),
+            http: meta("fetch%2Estatuscode"),
+            modified: meta("last-modified"),
+            info: (if ._source.status == "REDIRECTION" then meta("_redirto")
+                   else metas("error%2Ecause") end),
+            url: ._source.url
+        }] as $rows
+        | (["TYPE", "STATUS", "NEXT_FETCH", "LAST_FETCH", "INTERVAL", "LINKS", "HTTP",
+            "LAST_MODIFIED", "ERROR/REDIRECT", "URL"] | @tsv),
+          ($rows | sort_by(.type, .url)[]
+           | [.type, .status, .next, .last, .interval, .links, .http, .modified, .info, .url]
+           | @tsv),
+          "-- \($rows | length) sources: \($rows | group_by(.type)
+                | map("\(length) \(.[0].type)") | join(", "))",
+          (if .hits.total.value > ($rows | length)
+           then "WARNING: only \($rows | length) of \(.hits.total.value) sources shown; the"
+                + " missing ones are plain sitemaps or unflagged URLs (feeds and news/index/"
+                + "verified sitemaps are listed first). Narrow down with refetch_sources search"
+                + " <DOMAIN> <URL-REGEXP>."
+           else empty end)'
+}
+
+# per-domain list of feeds and sitemaps
+function __domain_sources () {
+    [ $# -gt 0 ] || { echo "domain_sources <HOST/DOMAIN>..."; exit 1; }
+    for DOMAIN in "$@"; do
+        echo "===== $DOMAIN"
+        ____sources_table "$DOMAIN" "$(____sources_query "$DOMAIN" '.*' "$SOURCE_TYPES_ALL")"
+    done
+}
+
+# re-arm the feeds and sitemaps of a host/domain
+#
+# Like reset_url, the status is set to DISCOVERED and the cached HTTP validators are
+# removed, so that the content is fetched and parsed again rather than answered by a
+# 304. The flags are kept: after the fetch the usual feed/sitemap intervals apply.
+# By default only flagged sources are affected; pass TYPES to narrow down or to include
+# "unflagged" ones (cf. ____sources_query).
+#
+# nextFetchDate is set to $REFETCH_DATE, default "now": the sources queue up behind the
+# domain's other due URLs. The spout takes at most opensearch.status.max.urls.per.bucket
+# URLs per domain and query, in ascending nextFetchDate order, so for a domain with a
+# large backlog of older DISCOVERED URLs "now" may mean weeks. Set REFETCH_DATE to a date
+# in the past (any expression accepted by `date -d`, e.g. 2000-01-01) to put the sources
+# first in their bucket instead.
+REFETCH_DATE="${REFETCH_DATE:-now}"
+function ____refetch_date () {
+    if [ "$REFETCH_DATE" == "now" ]; then ____now; else ____date "$REFETCH_DATE"; fi
+}
+function ____sources_action () {
+    NAME="$1"
+    CMND="$2"
+    DOMAIN="$3"
+    QUERY="$4"
+    case "$CMND" in
+        search )
+            ____sources_table "$DOMAIN" "$QUERY" ;;
+        count )
+            $SHOW_COMMAND
+            $CURL -XGET $ES_STATUS_URL'/_count?routing='"$DOMAIN" --data '{ "query": { '"$QUERY"' }}' \
+                | jq --raw-output '.count' ;;
+        update )
+            $SHOW_COMMAND
+            $CURL -XPOST $ES_STATUS_URL'/_update_by_query?pretty&routing='"$DOMAIN"'&conflicts=proceed&refresh=true' --data '{
+    "script": {
+        "lang": "painless",
+        "source": "ctx._source.status = \"DISCOVERED\"; ctx._source.nextFetchDate = params.date; for (k in params.remove) { ctx._source.metadata.remove(k) }",
+        "params": {
+            "date": "'"$(____refetch_date)"'",
+            "remove": ["signaturechangedate", "last-modified", "protocol%2Eetag",
+                       "error%2Esource", "error%2Ecause"]
+        }
+    },
+    "query": { '"$QUERY"' }
+}' | jq --raw-output '"updated \(.updated) of \(.total) sources" + (if (.failures | length) > 0 then ", \(.failures | length) FAILURES" else "" end)'
+            ;;
+        * )
+            echo "$NAME [search|count|update] <HOST/DOMAIN> [<URL-REGEXP> [<TYPES>]]"; exit 1 ;;
+    esac
+}
+
+function __refetch_sources () {
+    CMND="$1"
+    DOMAIN="$2"
+    URLREGEXP="${3:-.*}"
+    TYPES="${4:-$SOURCE_TYPES_FLAGGED}"
+    [ -n "$DOMAIN" ] || { echo "refetch_sources [search|count|update] <HOST/DOMAIN> [<URL-REGEXP> [<TYPES>]]"; exit 1; }
+    ____check_source_types "$TYPES"
+    ____sources_action refetch_sources "$CMND" "$DOMAIN" "$(____sources_query "$DOMAIN" "$URLREGEXP" "$TYPES")"
+}
+
+# feeds and sitemaps of a host/domain rejected by the pre-filter (error.cause=Filtered)
+#
+# After a host or domain has been removed from the fast URL filter, these are the
+# documents to re-arm: "update" does the same as refetch_sources. Unlike refetch_sources,
+# URLs that only look like a feed or sitemap ("unflagged") are included, because a seed
+# blocked before its first fetch has no flag. Restricting to Filtered documents keeps the
+# name-based match safe enough; check with "search" before "update" anyway.
+function __filtered_sources () {
+    CMND="$1"
+    DOMAIN="$2"
+    URLREGEXP="${3:-.*}"
+    TYPES="${4:-$SOURCE_TYPES_ALL}"
+    [ -n "$DOMAIN" ] || { echo "filtered_sources [search|count|update] <HOST/DOMAIN> [<URL-REGEXP> [<TYPES>]]"; exit 1; }
+    ____check_source_types "$TYPES"
+    ____sources_action filtered_sources "$CMND" "$DOMAIN" \
+        "$(____sources_query "$DOMAIN" "$URLREGEXP" "$TYPES" '{ "term": { "metadata.error%2Ecause": "Filtered" }}')"
+}
+
 # failed fetches (status not FETCHED) filtered by metadata
 function __failed_by_metadata () {
     CMND="$1"
@@ -744,7 +1020,7 @@ COMMAND="$1"; shift
 
 # the commands below already reduce their response to plain text with jq, so there is
 # no JSON left for -C to colorize
-if $COLORIZE && ! [[ "$COMMAND" =~ ^(aggregate|domain_report) ]]; then
+if $COLORIZE && ! [[ "$COMMAND" =~ ^(aggregate|domain_report|domain_sources|refetch_sources|filtered_sources) ]]; then
     __$COMMAND "$@" | jq --color-output --raw-output '.'
 else
     __$COMMAND "$@"

--- a/docs/status-sources.md
+++ b/docs/status-sources.md
@@ -1,0 +1,203 @@
+# Feeds and sitemaps in the status index
+
+`bin/status` has three sub-commands to inspect and re-arm the *crawl sources* of a host or domain, i.e. 
+its feeds and sitemaps: `domain_sources`, `refetch_sources` and `filtered_sources`. 
+
+They complement `domain_report`, which gives the status counts of a
+domain. The typical use is after a host or domain has been removed from the fast URL
+filter: find the feeds and sitemaps the filter killed and schedule them again.
+
+All commands need `curl` and `jq`, and read the index URL from `ES_STATUS_URL`
+(default `http://localhost:9200/status`).
+
+## How sources are represented
+
+A document in the status index is a source if one of these metadata flags is `"true"`:
+
+| flag | set by | meaning |
+|---|---|---|
+| `isfeed` | `FeedParserBolt`, `FeedDetectorBolt` | RSS/Atom feed |
+| `issitemapnews` | `NewsSiteMapParserBolt` | Google News sitemap |
+| `issitemapindex` | `NewsSiteMapParserBolt` | sitemap index (links to other sitemaps) |
+| `issitemapverified` | `NewsSiteMapParserBolt` | sitemap verified to contain news |
+| `issitemap` | sitemap discovery (robots.txt), `SiteMapParserBolt` | plain sitemap, not (yet) known to carry news |
+
+Flags are only assigned when a document is fetched and parsed (except `issitemap`, which
+sitemap discovery sets from robots.txt). 
+A seed that was rejected by the pre-filter
+before its first fetch therefore has **no flag at all**: it is an ERROR document with
+`error.cause=Filtered` and nothing else. 
+The commands below call such documents
+*unflagged* and find them by a name heuristic: the URL contains `sitemap`, `rss`,
+`feed` or `atom`, not followed by a letter (so `feeding` or `atomic` do not match).
+
+Because it is only a guess based on the URL, an `unflagged` row is a *candidate*, not
+a confirmed feed or sitemap. An ordinary article whose URL contains one of those words,
+such as `/world/china-feed-industry-unlikely-to-become-self-sufficient`, is listed as
+well although it is not a feed. Before re-arming `unflagged` rows, read their URLs and
+keep only those that look like a feed or sitemap address (`/rss.xml`, `/feed`,
+`/sitemap.xml`, `/feeds/posts/default`, ...).
+
+## `domain_sources <HOST/DOMAIN>...`
+
+Lists every source of the domain as a TSV table, one row per document, sorted by type
+and URL, followed by a summary line with counts per type.
+
+```
+$ bin/status domain_sources example.com | column -t -s $'\t'
+===== example.com
+TYPE          STATUS   NEXT_FETCH                LAST_FETCH            INTERVAL  LINKS  HTTP  LAST_MODIFIED                  ERROR/REDIRECT  URL
+feed          FETCHED  2026-09-08T18:00:00.000Z  2026-09-08T06:00:00Z  720       48     200   Tue, 08 Sep 2026 06:00:00 GMT  -               https://www.example.com/rss/homepage.xml
+sitemap-news  FETCHED  2026-09-09T06:00:00.000Z  2026-09-08T06:01:40Z  1440      312    200   -                              -               https://www.example.com/sitemap-news.xml
+sitemap       ERROR    -                         -                     -         -      -     -                              Filtered        https://www.example.com/sitemap-old.xml
+-- 3 sources: 1 feed, 1 sitemap, 1 sitemap-news
+```
+
+| column | source |
+|---|---|
+| TYPE | `feed`, `sitemap-news`, `sitemap-index`, `sitemap-verified`, `sitemap`, `unflagged` (first flag wins, in this order) |
+| STATUS | `status` |
+| NEXT_FETCH | `nextFetchDate`; `-` if the document is not scheduled |
+| LAST_FETCH | `protocol._request.time_` converted from epoch milliseconds |
+| INTERVAL | `fetchinterval` in minutes, as set by the scheduler |
+| LINKS | `numlinks`: outlinks found at the last parse |
+| HTTP | `fetch.statuscode` |
+| LAST_MODIFIED | `last-modified` header of the last fetch |
+| ERROR/REDIRECT | all values of `error.cause`, or the redirect target for REDIRECTION rows |
+
+The query is routed to the domain's shard (`key` is the routing field), so it is cheap
+even on a large index. At most 10000 rows are returned (`index.max_result_window`);
+feeds and news/index/verified sitemaps are fetched first so that, if the cap is hit,
+only plain sitemaps and unflagged candidates are cut off, and a warning with the exact
+total is printed.
+
+Handy filters on the output:
+
+```sh
+bin/status domain_sources example.com | sed '/^--/q' | column -t -s $'\t'   # table only
+bin/status domain_sources example.com | grep -v $'^sitemap\t'               # hide plain sitemaps
+bin/status domain_sources example.com | cut -f10 | awk -F/ '{print $3}' | sort | uniq -c | sort -rn   # hosts
+```
+
+## `refetch_sources [search|count|update] <HOST/DOMAIN> [<URL-REGEXP> [<TYPES>]]`
+
+Selects the sources of a domain and, with `update`, re-arms them so that they are
+fetched again:
+
+- `status` is set to `DISCOVERED`;
+- `nextFetchDate` is set to `$REFETCH_DATE`, default `now` (see below);
+- `last-modified`, `protocol.etag` and `signaturechangedate` are removed, so the next
+  fetch is a full one rather than a `304 Not Modified`;
+- `error.cause` and `error.source` are removed;
+- the flags are kept, so after the fetch the usual feed/sitemap intervals apply.
+
+`search` prints the same table as `domain_sources` for the selected documents, `count`
+prints their number. Always run one of them before `update`.
+
+Arguments:
+
+- **URL-REGEXP** (default `.*`) is an OpenSearch regular expression that must match the
+  **whole URL**, so start it with `.*` or the scheme. Escape literal dots (`\.`) and
+  question marks (`\?`), and quote the argument, otherwise the shell expands `.*` to the
+  dot files of the current directory.
+- **TYPES** (default: all flagged types, i.e. without `unflagged`) is a comma-separated
+  list of `feed`, `sitemap`, `sitemap-news`, `sitemap-index`, `sitemap-verified`,
+  `unflagged`. When `unflagged` is requested together with other types, documents
+  carrying one of the flags *not* requested are excluded, so `feed,unflagged` cannot
+  re-arm a sitemap named `sitemap.xml`.
+
+```sh
+bin/status refetch_sources search example.com
+bin/status refetch_sources update example.com '.*/sitemap\.xml'
+bin/status refetch_sources update example.com '.*' feed,sitemap-news
+```
+
+### `REFETCH_DATE`: mild or front of the queue
+
+The spout takes at most `opensearch.status.max.urls.per.bucket` URLs (5) per domain and
+query, **in ascending `nextFetchDate` order**, and the fetcher waits
+`fetcher.server.delay` (9 s) between requests to the same domain. Two consequences:
+
+- With the default `REFETCH_DATE=now` the re-armed sources queue up *behind* every
+  older DISCOVERED URL of the domain. For a domain with a short queue that is minutes;
+  for a domain with a backlog of a million discovered URLs it is weeks.
+- A date in the past puts them *first*, and the bucket itself first among the buckets:
+
+  ```sh
+  REFETCH_DATE=2000-01-01 bin/status refetch_sources update example.com '.*' feed,sitemap-news
+  ```
+
+`domain_report <domain>` shows the size of the queue: a large DISCOVERED count with
+SCHEDULED equal to it means a long wait with the default.
+
+For the same reason `fetch_now_url` is the wrong tool for a domain with a backlog, and
+`fetch_at_url <URL> 2000-01-01` the right one for a single URL.
+
+## `filtered_sources [search|count|update] <HOST/DOMAIN> [<URL-REGEXP> [<TYPES>]]`
+
+Same as `refetch_sources`, restricted to documents rejected by the pre-filter
+(`error.cause` contains `Filtered`), and including `unflagged` candidates by default.
+This is the command to use after a host or domain has been removed from the fast URL
+filter.
+
+```sh
+bin/status filtered_sources search example.com          # what did the filter kill?
+bin/status filtered_sources update example.com          # re-arm all of it
+bin/status filtered_sources update feedburner.com '.*' feed   # only the flagged feeds
+```
+
+## Workflow: after removing hosts or domains from the fast URL filter
+
+1. **Make sure the crawler has reloaded the filter.** Rules are loaded from S3 and
+   reloaded every `fast.urlfilter.refresh` seconds; if the property is unset or `-1`,
+   only a topology restart picks up the change. Re-armed URLs of a still-filtered domain
+   go straight back to ERROR/Filtered.
+
+2. **Triage.** For a list of domains:
+
+   ```sh
+   for d in example.com example.org; do
+       bin/status filtered_sources search "$d" > "$d.filtered"
+       printf '%-28s %s\n' "$d" "$(grep -E '^(--|WARNING)' "$d.filtered" | tr '\n' ' ')"
+   done
+   ```
+
+   Reading the summary lines:
+
+   | summary | meaning | action |
+   |---|---|---|
+   | `0 sources` | the filter killed no feed or sitemap | nothing (`domain_report` shows whether the domain is dormant) |
+   | a few feeds / news sitemaps / indexes | a real news source | `filtered_sources update <domain>` |
+   | only `unflagged` | seeds blocked before their first fetch, or false positives | read the file, `update` with TYPES `unflagged` or `reset_url` per URL |
+   | thousands of plain sitemaps or indexes, no feed, no news sitemap | a sitemap fan-out (catalogues, archives, per-channel sitemaps) | do **not** re-arm; consider a `Host` or `DenyPath` rule instead |
+   | few real feeds among many look-alikes (e.g. feedburner) | | `update ... '.*' feed` |
+
+3. **Re-arm** with `filtered_sources update`, narrowed with URL-REGEXP and TYPES where
+   needed. Examples from a real cleanup:
+
+   ```sh
+   # one feed per Blogger blog: the RSS variant of the posts feed
+   bin/status filtered_sources update blogspot.com 'https?://[^/]+\.blogspot\.com/feeds/posts/default\?alt=rss' feed
+   # news sitemaps hosted on S3, ignoring 3000 catalogue sitemaps
+   bin/status filtered_sources update amazonaws.com '.*' feed,sitemap-news
+   # the sitemap index and the news sitemap, not the 4000 per-channel sub-sitemaps
+   REFETCH_DATE=2000-01-01 bin/status filtered_sources update brighteon.com '.*/(channel-)?sitemap\.xml'
+   ```
+
+4. **Verify** after 15 to 30 minutes:
+
+   ```sh
+   bin/status filtered_sources count example.com      # 0 right after the update
+   bin/status refetch_sources search example.com | sed '/^--/q' | column -t -s $'\t'
+   bin/status domain_report example.com
+   ```
+
+   Good: STATUS `FETCHED`, LAST_FETCH minutes old, NEXT_FETCH in the future, LINKS > 0,
+   and DISCOVERED growing in `domain_report` as articles arrive. Bad outcomes are readable
+   in ERROR/REDIRECT: `robots.txt` (the site forbids it), a redirect target (the source
+   moved; the target was discovered instead), `Filtered` again (the filter still applies),
+   FETCH_ERROR (server did not answer; retried after 48 h, three times).
+
+**NOTE**: Re-fetching a sitemap index does not revive its (sitemaps) children. DISCOVERED URLs are
+  indexed with a `create` operation, which never overwrites an existing document. ERROR
+  children stay ERROR until their own retry date or a manual re-arm.


### PR DESCRIPTION
This PR adds three commands to the `./bin/status`: 
 - `domain_sources` which lists every source of the domain as a TSV table
 - `refetch_sources` search, count or trigger a refetch given a specific domain (+ an additional regex)
 - `filtered_sources` search, count or update a filtered sources given a specific domain (+ an additional regex, and type: feed, sitemap, etc..)
